### PR TITLE
Fix recipe remainders for meals

### DIFF
--- a/src/main/java/io/github/cottonmc/epicurean/container/CookingResultSlot.java
+++ b/src/main/java/io/github/cottonmc/epicurean/container/CookingResultSlot.java
@@ -5,10 +5,7 @@ import net.minecraft.container.CraftingResultSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.inventory.Inventory;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.recipe.Recipe;
-import net.minecraft.recipe.RecipeType;
 import net.minecraft.util.DefaultedList;
 
 public class CookingResultSlot extends CraftingResultSlot {
@@ -24,7 +21,7 @@ public class CookingResultSlot extends CraftingResultSlot {
 	@Override
 	public ItemStack onTakeItem(PlayerEntity player, ItemStack result) {
 		this.onCrafted(result);
-		DefaultedList<ItemStack> remainders = player.world.getRecipeManager().getRemainingStacks(RecipeType.CRAFTING, this.craftingInv, player.world);
+		DefaultedList<ItemStack> remainders = player.world.getRecipeManager().getRemainingStacks(EpicureanRecipes.MEAL, this.craftingInv, player.world);
 
 		for(int i = 0; i < remainders.size(); ++i) {
 			ItemStack ingredient = this.craftingInv.getInvStack(i);
@@ -33,7 +30,7 @@ public class CookingResultSlot extends CraftingResultSlot {
 				this.craftingInv.takeInvStack(i, 1);
 				ingredient = this.craftingInv.getInvStack(i);
 			}
-			if (!ingredient.getItem().hasRecipeRemainder()) continue;
+
 			if (!remainder.isEmpty()) {
 				if (ingredient.isEmpty()) {
 					this.craftingInv.setInvStack(i, remainder);

--- a/src/main/java/io/github/cottonmc/epicurean/item/JellyItem.java
+++ b/src/main/java/io/github/cottonmc/epicurean/item/JellyItem.java
@@ -11,11 +11,6 @@ public class JellyItem extends SeasoningItem {
 	}
 
 	@Override
-	public boolean hasRecipeRemainder() {
-		return true;
-	}
-
-	@Override
 	public boolean hasEnchantmentGlint(ItemStack stack) {
 		return stack.getItem() == EpicureanItems.SUPER_JELLY;
 	}

--- a/src/main/java/io/github/cottonmc/epicurean/item/MealItem.java
+++ b/src/main/java/io/github/cottonmc/epicurean/item/MealItem.java
@@ -34,12 +34,6 @@ public class MealItem extends Item implements DynamicFood {
 	}
 
 	@Override
-	public boolean hasRecipeRemainder() {
-		return false;
-	}
-	
-
-	@Override
 	public ItemStack finishUsing(ItemStack stack, World world, LivingEntity entity) {
 		if (entity instanceof PlayerEntity) {
 			PlayerEntity player = (PlayerEntity)entity;

--- a/src/main/java/io/github/cottonmc/epicurean/item/SeasoningItem.java
+++ b/src/main/java/io/github/cottonmc/epicurean/item/SeasoningItem.java
@@ -22,11 +22,6 @@ public class SeasoningItem extends Item implements Seasoning {
 		this.effect = effect;
 	}
 
-	@Override
-	public boolean hasRecipeRemainder() {
-		return false;
-	}
-
 	public int getHungerRestored(ItemStack stack) {
 		return this.hungerRestored;
 	}


### PR DESCRIPTION
Resolves #13 

I can infer that `CookingResultSlot#onTakeItem` is a slightly modified version of the method it overrides. By looking up CRAFTING recipes instead of MEAL recipes, a matching recipe cannot be found, resulting in no remainders. Additionally, the check for `hasRecipeRemainder` seems to be an unnecessary addition that only contributes to the issue.

I was unable to reproduce the duplication issue described in #12 (I had to substitute porkchops for pancakes) with these changes. If there are other ways to produce duplications, I'll need some help with testing those.

I don't believe the various overrides of `Item#hasRecipeRemainder` are effective. This is what the base method does:
```java
   public boolean hasRecipeRemainder() {
      return this.recipeRemainder != null;
   }
```
The overrides effectively don't change anything because they match which items have the recipe remainder set in their settings and which ones do not. I have therefore removed the overrides to avoid any confusion this might cause.